### PR TITLE
Use 'map' argument in map.launch

### DIFF
--- a/launch/map.launch
+++ b/launch/map.launch
@@ -9,10 +9,10 @@
 
   <!-- Setup map -->
   <node name="map_setup" pkg="pal_navigation_sm" type="map_setup.py">
-    <param name="map" value="$(env HOME)/.pal/tiago_maps/config"/>
+    <param name="map" value="$(arg map)"/>
   </node>
 
   <!-- Run the map server -->
-  <node name="map_server" pkg="map_server" type="map_server" args="$(env HOME)/.pal/tiago_maps/config/map.yaml"/>
+  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map)/map.yaml"/>
 
 </launch>


### PR DESCRIPTION
In map.launch the argument 'map' was provided but never used when starting the
node. This commit fixes the launch file in the sense that it uses that argument
instead of using the hand-coded-path for ~/.pal/tiago_maps/config that has
previously been used.