### PR TITLE
Install scripts base_maps_symlink.sh, cp_maps_to_home.sh and cp_pose_…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ catkin_package()
 
 install(
   PROGRAMS
+    scripts/base_maps_symlink.sh
+    scripts/cp_maps_to_home.sh
+    scripts/cp_pose_to_home.sh
     scripts/map_setup.py
     scripts/pal_navigation_main_sm.py
     scripts/navigation.sh


### PR DESCRIPTION
…to_home.sh

When not installing them, I get some *not found* errors when using catkin in *install* mode.