### PR TITLE
Fix mode syntax to work also on noetic

### DIFF
--- a/scripts/pal_navigation_main_sm.py
+++ b/scripts/pal_navigation_main_sm.py
@@ -93,7 +93,7 @@ class MapsManagerService():
             transf.write(DEFAULT_TRANSFORMATION)
 
         # Set permisions
-        self._chmod(map_path, 0777)
+        self._chmod(map_path, 0o777)
 
         # Save initial pose of the robot in the map
         rospack = rospkg.RosPack()


### PR DESCRIPTION
To fix this error
```
  File "/home/user/exchange/gallium/pmb3_public_ws/src/pal_navigation_sm/scripts/pal_navigation_main_sm.py", line 96
    self._chmod(map_path, 0777)
                             ^
SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers
```
